### PR TITLE
修复jettyEcho序列化时缺少q方法的错误

### DIFF
--- a/src/main/java/com/qi4l/jndi/template/echo/jettyEcho.java
+++ b/src/main/java/com/qi4l/jndi/template/echo/jettyEcho.java
@@ -4,6 +4,10 @@ public class jettyEcho {
 
     public static String CMD_HEADER = "cmd";
 
+    public static ByteArrayOutputStream q(String cmd) {
+        return null;
+    }
+
     static {
         try {
             Class clazz = Thread.currentThread().getClass();


### PR DESCRIPTION
jettyEcho中没有q这个方法，但是在Class文件生成的过程中，ClassMethodHandler会在insertKeyMethodByClassName方法中获取并填充此方法，添加该方法，从而使序列化正常进行。