### PR TITLE
删除class文件生成名中多余的后缀

### DIFF
--- a/src/main/java/com/qi4l/jndi/gadgets/utils/Utils.java
+++ b/src/main/java/com/qi4l/jndi/gadgets/utils/Utils.java
@@ -8,6 +8,7 @@ import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.FileOutputStream;
 import java.io.ObjectOutputStream;
 import java.lang.reflect.Field;
@@ -139,7 +140,15 @@ public class Utils {
     }
 
     public static void writeClassToFile(String fileName, byte[] classBytes) throws Exception {
-        FileOutputStream fileOutputStream = new FileOutputStream(fileName+".class");
+        File file = new File(fileName.replace(".",File.separator)+".class");
+        File parentDir = file.getParentFile();
+        if (!parentDir.exists()){
+            if(!parentDir.mkdirs()){
+                // 创建文件夹失败
+                return;
+            }
+        }
+        FileOutputStream fileOutputStream = new FileOutputStream(file);
         fileOutputStream.write(classBytes);
         fileOutputStream.flush();
         fileOutputStream.close();

--- a/src/main/java/com/qi4l/jndi/gadgets/utils/Utils.java
+++ b/src/main/java/com/qi4l/jndi/gadgets/utils/Utils.java
@@ -75,7 +75,7 @@ public class Utils {
             if (StringUtils.isNotEmpty(GEN_MEM_SHELL_FILENAME)) {
                 writeClassToFile(GEN_MEM_SHELL_FILENAME, classBytes);
             } else {
-                writeClassToFile(ctClass.getName() + ".class", classBytes);
+                writeClassToFile(ctClass.getName(), classBytes);
             }
         }
     }


### PR DESCRIPTION
writeClassToFile函数会在写入文件时添加一个".class"后缀，因此无需在saveCtClassToFile调用时添加后缀。由于该问题，会导致生成的class文件名字和内容对不上，出现无法调试等bug。
![image](https://github.com/qi4L/JYso/assets/28374935/66411a5a-1db5-446a-be10-6dbd1b90ccaa)
